### PR TITLE
Revert "Merge pull request #28 from DataScienceUIBK/revert-27-eval_sc…

### DIFF
--- a/examples/generator_chain_of_thought.py
+++ b/examples/generator_chain_of_thought.py
@@ -1,0 +1,36 @@
+import torch
+from rankify.dataset.dataset import Document, Question, Answer, Context
+from rankify.generator.generator import Generator
+
+# Define question and answer placeholder
+question = Question("What is the largest Portuguese-speaking city in the world?")
+answers = Answer("")
+
+# Define contexts
+contexts = [
+    Context(id=1, title="Portuguese Language Distribution", text=(
+        "Portuguese is spoken in many countries, including Portugal, Brazil, Angola, Mozambique, and others. "
+        "Among these, Brazil has the largest population of Portuguese speakers."), score=0.9),
+    
+    Context(id=2, title="Population Facts", text=(
+        "Brazil has the most populous city in these countries."), score=0.8),
+
+    Context(id=3, title="São Paulo vs Lisbon", text=(
+        "São Paulo is the most populous city in Brazil. It is widely recognized as the largest Portuguese-speaking city in the world. "
+        "In comparison, Lisbon, the capital of Portugal, has a much smaller population than São Paulo."), score=0.95),
+]
+
+# Construct document
+doc = Document(question=question, answers=answers, contexts=contexts)
+
+# Initialize Generator
+generator = Generator(
+    method="chain-of-thought-rag",
+    model_name='meta-llama/Meta-Llama-3.1-8B-Instruct',
+    backend="huggingface",
+    torch_dtype=torch.float16
+)
+
+# Generate answer
+generated_answers = generator.generate([doc])
+print(generated_answers)  # Expected output: ["São Paulo"]

--- a/examples/generator_custom_prompt.py
+++ b/examples/generator_custom_prompt.py
@@ -14,9 +14,17 @@ contexts = [
 # Construct document
 doc = Document(question=question, answers=answers, contexts=contexts)
 
+custom_prompt = (
+    "Please answer the following question using only the provided context.\n"
+    "Q: {question}\n"
+    "Context:\n{contexts}\n"
+    "A:"
+)
+
+
 # Initialize Generator (e.g., Meta Llama)
-generator = Generator(method="chain-of-thought-rag", model_name='meta-llama/Meta-Llama-3.1-8B-Instruct', backend="huggingface", torch_dtype=torch.float16)
+generator = Generator(method="basic-rag", model_name='meta-llama/Meta-Llama-3.1-8B-Instruct', backend="huggingface", torch_dtype=torch.float16)
 
 # Generate answer
-generated_answers = generator.generate([doc])
+generated_answers = generator.generate([doc], custom_prompt=custom_prompt)
 print(generated_answers)  # Output: ["Paris"]

--- a/examples/generator_self_consistency.py
+++ b/examples/generator_self_consistency.py
@@ -1,0 +1,56 @@
+from rankify.dataset.dataset import Document, Question, Answer, Context
+from rankify.generator.generator import Generator
+import torch
+
+from rankify.models.sentence_transformer_reranker import SentenceTransformerReranker
+
+# Define a more ambiguous question and answer placeholder
+question = Question("Which city is the cultural capital of the United States?")
+answers = Answer("")
+
+# Define contexts with evidence for multiple possible answers
+contexts = [
+    Context(
+        id=1,
+        title="New York City Culture",
+        text=(
+            "New York City is often called the cultural capital of the United States. "
+            "It is home to Broadway, world-class museums, and a vibrant arts scene."
+        ),
+        score=0.95
+    ),
+    Context(
+        id=2,
+        title="Los Angeles Arts",
+        text=(
+            "Los Angeles is known for its film and music industries, and is considered by many to be the entertainment capital of the world."
+        ),
+        score=0.9
+    ),
+    Context(
+        id=3,
+        title="Chicago's Cultural Influence",
+        text=(
+            "Chicago has a rich history in music, theater, and architecture, and is sometimes referred to as the cultural capital of the Midwest."
+        ),
+        score=0.95
+    ),
+]
+
+# Construct document
+doc = Document(question=question, answers=answers, contexts=contexts)
+
+
+reranker = SentenceTransformerReranker(method="sentence_transformer_reranker", model_name="all-MiniLM-L6-v2")
+
+generator = Generator(
+    method="self-consistency-rag",
+    model_name='meta-llama/Meta-Llama-3.1-8B-Instruct',
+    backend="huggingface",
+    torch_dtype=torch.float16,
+    num_samples=7,  # Number of samples for self-consistency
+    reranker=reranker,  # Optional reranker for better answer selection
+)
+
+generated_answers = generator.generate([doc])
+print(generated_answers)  # Output may vary: ["New York City"], ["Los Angeles"], ["Chicago"], etc.

--- a/examples/generator_vllm.py
+++ b/examples/generator_vllm.py
@@ -15,14 +15,16 @@ contexts = [
 doc = Document(question=question, answers=answers, contexts=contexts)
 
 # Define sampling parameters for vllm
-sampling_params = SamplingParams(temperature=0.7, top_p=0.9, max_tokens=100)
+sampling_params = SamplingParams(temperature=0.7, top_p=0.95, max_tokens=32, n=1, stop=["###", "</s>", "\n\n", "."])# stop=["\n"])
 
 # Initialize Generator (e.g., Meta Llama)
-generator = Generator(method="basic-rag", model_name='mistralai/Mistral-7B-v0.1', backend="vllm", dtype="float16")
+generator = Generator(method="basic-rag", model_name='meta-llama/Meta-Llama-3.1-8B-Instruct', backend="vllm", dtype="float16",  max_model_len=2048)
 
 # Generate answer
 generated_answers = generator.generate([doc],sampling_params=sampling_params)
 
-output = generated_answers[0][0]
-print(output.prompt.strip())
-print(output.outputs[0].text.strip())  # Output: ["Paris"]
+# Print the generated answers
+print(generated_answers) 
+#output = generated_answers[0][0]
+#print(output.prompt.strip())
+#print(output.outputs[0].text.strip())  # Output: ["Paris"]

--- a/examples/rag_evaluation.py
+++ b/examples/rag_evaluation.py
@@ -1,0 +1,45 @@
+import os
+
+import torch
+from vllm import SamplingParams
+
+from rankify.generator.generator import Generator
+os.environ["CUDA_VISIBLE_DEVICES"] = "0"
+from rankify.dataset.dataset import Dataset, Document, Context, Question, Answer
+from rankify.metrics.metrics import Metrics
+
+datasets = ["web_questions-test"] #nq-test , triviaqa-test
+
+for name in datasets:
+    print("*" * 100)
+    print(name)
+    dataset = Dataset('bm25', name, 5)
+    documents = dataset.download(force_download=False)
+
+    # Limit to a small subset for fast evaluation
+    N = 2  # Change this to the number you want to process
+    documents = documents[:N]
+
+    print(len(documents[0].contexts), documents[0].answers)
+    print(len(documents[0].answers.answers))
+
+    # Define sampling parameters for vllm
+    sampling_params = SamplingParams(temperature=0.7, top_p=0.95, max_tokens=32, n=1, stop=["###", "</s>", "\n\n", "\n","."])# stop=["\n"])
+
+    # Inntitialize Generator (e.g., Meta Llama)
+    #qwen 2.5  (1,4,7,)
+    #llama 3.2 (1,3,) llama 3.1 (8)
+    # gemma 3 (4b)
+    # 
+    generator = Generator(method="basic-rag", model_name='meta-llama/Meta-Llama-3.1-8B-Instruct', backend="vllm", dtype="float16",  max_model_len=2048)
+
+    # Generate answer
+    generated_answers = generator.generate(documents=documents, sampling_params=sampling_params)
+
+    metrics = Metrics(documents)
+
+    print(generated_answers)
+    generation_metrics = metrics.calculate_generation_metrics(generated_answers)
+    print(generation_metrics)
+    print("#" * 100)
+    dataset.save_dataset("webq-bm25-test-small.json", save_text=True)

--- a/examples/rag_methods_evaluation.py
+++ b/examples/rag_methods_evaluation.py
@@ -1,0 +1,98 @@
+import os
+import torch
+
+from rankify.generator.generator import Generator
+from rankify.dataset.dataset import Dataset
+from rankify.metrics.metrics import Metrics
+
+os.environ["CUDA_VISIBLE_DEVICES"] = "0"
+
+# Datasets to evaluate
+DATASETS = [
+    "web_questions-test",
+    "nq-test",
+    "triviaqa-test",
+    "strategyqa-test"
+]
+
+# RAG methods to evaluate
+RAG_METHODS = [
+    "basic-rag",
+    "chain-of-thought-rag",
+    "fid",
+    "in-context-ralm",
+    "zero-shot",
+    "self-consistency-rag"
+]
+
+# Models to evaluate (extend this list as needed, all use same config for now)
+MODELS = [
+    {
+        "model_name": 'meta-llama/Meta-Llama-3.1-8B-Instruct',
+        "backend": "huggingface",
+    },
+    # Add more model configs as dicts here
+]
+
+N_DOCS = 5  # Number of docs to retrieve per query
+
+# Number of questions to evaluate per dataset (set to None to use all)
+N_QUESTIONS = 1  # e.g., 1 for one question, 10 for ten, None for all
+
+# Generation parameters for HuggingFace models (pass as kwargs)
+generation_kwargs = dict(
+    temperature=0.7,
+    top_p=0.95,
+    max_new_tokens=32,
+    num_return_sequences=1,
+)
+
+results = {}
+
+for model_cfg in MODELS:
+    print("\n" + "#" * 120)
+    print(f"Evaluating model: {model_cfg['model_name']}")
+    results[model_cfg['model_name']] = {}
+    for dataset_name in DATASETS:
+        print("=" * 120)
+        print(f"Evaluating dataset: {dataset_name}")
+        dataset = Dataset('bm25', dataset_name, N_DOCS)
+        documents = dataset.download(force_download=False)
+        if N_QUESTIONS is not None:
+            documents = documents[:N_QUESTIONS]
+        metrics = Metrics(documents)
+        results[model_cfg['model_name']][dataset_name] = {}
+
+        for rag_method in RAG_METHODS:
+            print("-" * 80)
+            print(f"Testing RAG method: {rag_method}")
+            generator = Generator(
+                method=rag_method,
+                **model_cfg  # Pass all model parameters as kwargs
+            )
+            try:
+                generated_answers = generator.generate(
+                    documents=documents,
+                    **generation_kwargs
+                )
+            except Exception as e:
+                print(f"Error with method {rag_method} on dataset {dataset_name}: {e}")
+                generated_answers = [""] * len(documents)
+
+            print(f"Generated answers ({rag_method}): {generated_answers}")
+            generation_metrics = metrics.calculate_generation_metrics(generated_answers)
+            print(f"Generation metrics ({rag_method}): {generation_metrics}")
+            results[model_cfg['model_name']][dataset_name][rag_method] = generation_metrics
+
+        print("=" * 120)
+        # Optionally save intermediate results
+        dataset.save_dataset(f"{dataset_name}-bm25-eval.json", save_text=True)
+
+# Print summary
+print("\n\nBenchmark Results Summary:")
+for model_name, model_results in results.items():
+    print(f"\nModel: {model_name}")
+    for dataset_name, rag_results in model_results.items():
+        print(f"  Dataset: {dataset_name}")
+        for rag_method, metrics_dict in rag_results.items():
+            print(f"    {rag_method}: {metrics_dict}")

--- a/rankify/dataset/dataset.py
+++ b/rankify/dataset/dataset.py
@@ -538,9 +538,18 @@ class Dataset:
         """
         dpr_data = []
         for doc in self.documents:
+            if hasattr(doc.answers, "answers"):
+                answers = doc.answers.answers
+            elif isinstance(doc.answers, (list, tuple)):
+                answers = list(doc.answers)
+            elif isinstance(doc.answers, str):
+                answers = [doc.answers]
+            else:
+                answers = [str(doc.answers)]
+
             dpr_entry = {
                 "question": doc.question.question,
-                "answers": doc.answers.answers,
+                "answers": answers,
                 "ctxs": [ctx.to_dict(save_text) for ctx in doc.contexts]
             }
             if save_reranked:

--- a/rankify/generator/generator.py
+++ b/rankify/generator/generator.py
@@ -68,7 +68,7 @@ class Generator:
         self.rag_method = rag_method_class(model, **kwargs)
 
 
-    def generate(self, documents, **kwargs):
+    def generate(self, documents, custom_prompt=None,**kwargs):
         """
         Generates answers based on the **input documents**.
 
@@ -86,4 +86,4 @@ class Generator:
             # Output: ['William Shakespeare wrote Hamlet in the early 1600s.']
             ```
         """
-        return self.rag_method.answer_questions(documents, **kwargs)
+        return self.rag_method.answer_questions(documents, custom_prompt, **kwargs)

--- a/rankify/generator/models/huggingface_model.py
+++ b/rankify/generator/models/huggingface_model.py
@@ -25,13 +25,29 @@ class HuggingFaceModel(BaseRAGModel):
         self.model = model
         self.prompt_generator = prompt_generator
 
-    def generate(self, prompt: str, **kwargs) -> str:
-        """Generate a response using Hugging Face's model."""
-        inputs = self.tokenizer(prompt, return_tensors="pt").to(self.model.device) # ensure inputs are on the same device as the model
-        # define generation parameters defaults TODO: should be excluded into config
-        kwargs.setdefault("max_length", 128)
-        kwargs.setdefault("temperature", 0.7)
-        
+    def generate(self, prompt: str, **kwargs):
+        """Generate a response using Hugging Face's model and return only the answer(s)."""
+        inputs = self.tokenizer(prompt, return_tensors="pt").to(self.model.device)
+
+        kwargs.setdefault("max_new_tokens", 64)
+        kwargs.setdefault("do_sample", True)
+        kwargs.setdefault("num_return_sequences", 1)
+        kwargs.setdefault("eos_token_id", self.tokenizer.eos_token_id)
+        kwargs.setdefault("pad_token_id", self.tokenizer.eos_token_id)
 
         outputs = self.model.generate(**inputs, **kwargs)
-        return self.tokenizer.decode(outputs[0], skip_special_tokens=True)
+
+    # If multiple sequences requested, decode all
+        if kwargs.get("num_return_sequences", 1) > 1:
+            answers = []
+            for output in outputs:
+                generated_text = self.tokenizer.decode(output, skip_special_tokens=True)
+                answer = generated_text[len(prompt):].strip()
+                answer = answer.split("\n")[0].strip()
+                answers.append(answer)
+            return answers
+        else:
+            generated_text = self.tokenizer.decode(outputs[0], skip_special_tokens=True)
+            answer = generated_text[len(prompt):].strip()
+            answer = answer.split("\n")[0].strip()
+            return answer

--- a/rankify/generator/models/vllm_model.py
+++ b/rankify/generator/models/vllm_model.py
@@ -44,4 +44,10 @@ class VLLMModel(BaseRAGModel):
         # Call the vLLM API using the LLM client
         response = self.llm.generate(prompt, kwargs["sampling_params"])
         
-        return response
+        if response and response[0].outputs:
+            # Extract the generated text from the response
+            generated_text = response[0].outputs[0].text.strip()
+        else:
+            generated_text = ""
+
+        return generated_text

--- a/rankify/generator/prompt_template.py
+++ b/rankify/generator/prompt_template.py
@@ -1,0 +1,35 @@
+from typing import List, Optional
+from enum import Enum
+
+class PromptTemplate(Enum):
+    BASIC_RAG = "basic-rag"
+    CHAIN_OF_THOUGHT_RAG = "chain-of-thought-rag"
+    ZERO_SHOT = "zero-shot"
+    SELF_CONSISTENCY_RAG = "self-consistency-rag"
+
+DEFAULT_PROMPTS = {
+    PromptTemplate.BASIC_RAG: (
+        "You are a helpful assistant. Give a single, concise answer to the question.\n"
+        "Since I want to use this for evaluation, only the single answer helps me a lot more and there is no point in explaining it.\n"
+        "Question: {question}\n"
+        "Contexts:\n{contexts}\n"
+        "Answer:"
+    ),
+    PromptTemplate.CHAIN_OF_THOUGHT_RAG: (
+        "You are a helpful assistant. Think step by step and then answer concisely with only the answer, since I want to evaluate it that is my best option to get it without explanation.\n"
+        "Question: {question}\n"
+        "Contexts:\n{contexts}\n"
+        "Let's think step by step.\nAnswer:"
+    ),
+    PromptTemplate.SELF_CONSISTENCY_RAG: (
+        "You are a helpful assistant. Think step by step and then answer concisely with only the answer, since I want to evaluate it that is my best option to get it without explanation.\n"
+        "Question: {question}\n"
+        "Contexts:\n{contexts}\n"
+        "Let's think step by step.\nAnswer:"
+    ),
+    PromptTemplate.ZERO_SHOT: (
+        "Answer the following question.\n"
+        "Question: {question}\n"
+        "Answer:"
+    ),
+}

--- a/rankify/generator/rag_methods/base_rag_method.py
+++ b/rankify/generator/rag_methods/base_rag_method.py
@@ -4,7 +4,7 @@ from rankify.dataset.dataset import Document
 
 class BaseRAGMethod(ABC):
     @abstractmethod
-    def answer_questions(self, documents: List[Document], **kwargs) -> List[str]:
+    def answer_questions(self, documents: List[Document], custom_prompt=None, **kwargs) -> List[str]:
         """
         Abstract method to answer a question based on a list of documents.
         """

--- a/rankify/generator/rag_methods/basic_rag.py
+++ b/rankify/generator/rag_methods/basic_rag.py
@@ -9,7 +9,7 @@ class BasicRAG(BaseRAGMethod):
     def __init__(self, model: BaseRAGModel, **kwargs):
         self.model = model
 
-    def answer_questions(self, documents: List[Document], **kwargs) -> List[str]:
+    def answer_questions(self, documents: List[Document], custom_prompt=None, **kwargs) -> List[str]:
         """
         Answer question for a list of documents using the model.
 
@@ -27,13 +27,10 @@ class BasicRAG(BaseRAGMethod):
             contexts = [context.text for context in document.contexts]
 
             # Construct the prompt
-            prompt = f"""Answer this question based on the given contexts, provide a concise answer. You only need to answer the question, not provide context.
-            Question: {question}\nContexts:\n""" + "\n".join(contexts)
-
+            prompt = self.model.prompt_generator.generate_user_prompt(question, contexts, custom_prompt)
             # Generate the answer using the model
             answer = self.model.generate(prompt=prompt, **kwargs)
             
             # Append the answer to the list
             answers.append(answer)
-
         return answers

--- a/rankify/generator/rag_methods/chain_of_thought_rag.py
+++ b/rankify/generator/rag_methods/chain_of_thought_rag.py
@@ -25,7 +25,7 @@ class ChainOfThoughtRAG(BaseRAGMethod):
     def __init__(self, model: BaseRAGModel, **kwargs):
         self.model = model
 
-    def answer_questions(self, documents: List[Document], **kwargs) -> List[str]:
+    def answer_questions(self, documents: List[Document], custom_prompt=None, **kwargs) -> List[str]:
         """Answer a question using chain-of-thought reasoning."""
         answers = []
 
@@ -35,10 +35,8 @@ class ChainOfThoughtRAG(BaseRAGMethod):
             contexts = [context.text for context in document.contexts]
 
             # Construct the prompt
-            prompt = f"""Answer this question using internal chain of thought reasoning, think and
-          lay out your logic in multiple steps. You may use the provided contexts, but you can also discard it and just 
-             reason by your own knowledge.   :\nQuestion: {question}\nContexts:\n""".join(contexts)
-        
+            prompt = self.model.prompt_generator.generate_user_prompt(question, contexts, custom_prompt)
+            
             # Generate the answer using the model
             answer = self.model.generate(prompt=prompt, **kwargs)
             

--- a/rankify/generator/rag_methods/fid_rag_method.py
+++ b/rankify/generator/rag_methods/fid_rag_method.py
@@ -31,7 +31,7 @@ class FiDRAGMethod(BaseRAGMethod):
     def __init__(self, model: BaseRAGModel):
         self.model = model
 
-    def answer_questions(self, documents: List[Document], **kwargs) -> List[str]:
+    def answer_questions(self, documents: List[Document], custom_prompt=None, **kwargs) -> List[str]:
         """
         Answer questions for a list of documents using the model.
 

--- a/rankify/generator/rag_methods/in_context_ralm_rag.py
+++ b/rankify/generator/rag_methods/in_context_ralm_rag.py
@@ -144,7 +144,7 @@ class InContextRALMRAG(BaseRAGMethod):
 
         return examples
 
-    def answer_questions(self, documents: List[Document]) -> List[str]:
+    def answer_questions(self, documents: List[Document], custom_prompt=None) -> List[str]:
         """
         Generates answers for **a list of documents** using RALM.
 

--- a/rankify/generator/rag_methods/self_consistency_rag.py
+++ b/rankify/generator/rag_methods/self_consistency_rag.py
@@ -1,0 +1,55 @@
+from typing import List, Optional
+from collections import Counter
+from rankify.generator.models.base_rag_model import BaseRAGModel
+from rankify.dataset.dataset import Document, Answer
+from rankify.generator.rag_methods.base_rag_method import BaseRAGMethod
+
+class SelfConsistencyRAG(BaseRAGMethod):
+    def __init__(self, model: BaseRAGModel, num_samples: int = 5, reranker=None, **kwargs):
+        self.model = model
+        self.num_samples = num_samples
+        self.reranker = reranker  # Optional: pass a reranker instance
+
+    def answer_questions(self, documents: List[Document], custom_prompt: Optional[str] = None, **kwargs) -> List[str]:
+        """
+        For each document, generate multiple answers and aggregate by majority vote or reranker.
+        """
+        answers = []
+        for document in documents:
+            question = document.question.question
+            contexts = [context.text for context in document.contexts]
+            prompt = self.model.prompt_generator.generate_user_prompt(question, contexts, custom_prompt)
+
+            # Generate multiple answers in one call
+            sample_answers = self.model.generate(
+                prompt=prompt,
+                do_sample=True,
+                num_return_sequences=self.num_samples,
+                **kwargs
+            )
+
+            # Ensure sample_answers is a list
+            if isinstance(sample_answers, str):
+                sample_answers = [sample_answers]
+
+            print(f"Generated {len(sample_answers)} samples: {sample_answers}")
+
+            # Use reranker if provided, otherwise majority vote
+            if self.reranker:
+                rerank_docs = []
+                for ans in sample_answers:
+                    doc = Document(question=document.question, answers=Answer(answers=[ans]), contexts=document.contexts)
+                    rerank_docs.append(doc)
+                reranked = self.reranker.rank(rerank_docs)
+                best_answer = reranked[0].answers.answers
+                if isinstance(best_answer, list):
+                    best_answer = best_answer[0]
+                answers.append(best_answer)
+            else:
+                # Majority vote (with normalization)
+                def normalize(text):
+                    return text.lower().strip()
+                normalized = [normalize(ans) for ans in sample_answers]
+                most_common, _ = Counter(normalized).most_common(1)[0]
+                answers.append(most_common)
+        return answers

--- a/rankify/generator/rag_methods/zero_shot.py
+++ b/rankify/generator/rag_methods/zero_shot.py
@@ -24,7 +24,7 @@ class ZeroShotRAG(BaseRAGMethod):
         """
         self.model = model
 
-    def answer_questions(self, documents: List[Document], **kwargs) -> List[str]:
+    def answer_questions(self, documents: List[Document], custom_prompt=None, **kwargs) -> List[str]:
         """
         Answer questions for a list of documents using the model in a zero-shot manner.
 
@@ -40,9 +40,9 @@ class ZeroShotRAG(BaseRAGMethod):
             # Extract question and contexts from the document
             question = document.question.question
             
-            # Construct the prompt by adding question
-            prompt = f"Question: {question}\n"
-
+            # Construct the prompt
+            prompt = self.model.prompt_generator.generate_user_prompt(question, None, custom_prompt)
+            
             # Generate the answer using the model
             answer = self.model.generate(prompt, **kwargs)
 

--- a/rankify/metrics/metrics.py
+++ b/rankify/metrics/metrics.py
@@ -66,6 +66,28 @@ class BaseMetric:
         """
         return {}, []
 
+    # def get_dataset_answer(self, data):
+    #     """
+    #     Extracts ground-truth answers from dataset.
+
+    #     Args:
+    #         data: Data object containing documents.
+
+    #     Returns:
+    #         list: List of ground-truth answers.
+    #     """
+    #     answers_list = []
+    #     for doc in data.documents:
+    #         ans = doc.answers
+    #         if hasattr(ans, "answers"):
+    #             answers_list.append(ans.answers)
+    #         elif isinstance(ans, (list, tuple)):
+    #             answers_list.append(list(ans))
+    #         elif isinstance(ans, str):
+    #             answers_list.append([ans])
+    #         else:
+    #             answers_list.append([str(ans)])
+    #     return answers_list
     def get_dataset_answer(self, data):
         """
         Extracts ground-truth answers from dataset.
@@ -76,9 +98,8 @@ class BaseMetric:
         Returns:
             list: List of ground-truth answers.
         """
+        #print(data.doc)
         return [doc.answers.answers for doc in data.documents]
-
-
 ### **Generation Metrics (Exact Match, F1, Precision, Recall, BLEU)**
 
 class ExactMatch(BaseMetric):
@@ -100,6 +121,7 @@ class ExactMatch(BaseMetric):
         Returns:
             float: **1.0** if there is an exact match, else **0.0**.
         """
+
         normalized_prediction = normalize_answer(prediction)
         for answer in golden_answers:
             if normalize_answer(answer) == normalized_prediction:
@@ -408,6 +430,7 @@ class Metrics:
             documents (list): List of **Document** instances.
         """
         self.documents = documents
+        print()
         self.config = {"dataset_name": "QA_Evaluation"}
 
     def top_k_accuracy(self, k, use_reordered=False):

--- a/rankify/utils/generator/generator_models.py
+++ b/rankify/utils/generator/generator_models.py
@@ -2,6 +2,7 @@ from rankify.generator.rag_methods.basic_rag import BasicRAG
 from rankify.generator.rag_methods.chain_of_thought_rag import ChainOfThoughtRAG
 from rankify.generator.rag_methods.fid_rag_method import FiDRAGMethod
 from rankify.generator.rag_methods.in_context_ralm_rag import InContextRALMRAG
+from rankify.generator.rag_methods.self_consistency_rag import SelfConsistencyRAG
 from rankify.generator.rag_methods.zero_shot import ZeroShotRAG
 
 
@@ -11,4 +12,5 @@ RAG_METHODS = {
     "zero-shot": ZeroShotRAG,
     "basic-rag": BasicRAG,
     "chain-of-thought-rag": ChainOfThoughtRAG,
+    "self-consistency-rag": SelfConsistencyRAG,
 }


### PR DESCRIPTION
Reverting the changes from PR 27 to account for authorship and now inlcude all new changes like:

Implemented Self-Consistency, Chain-of-Thought, Zero-shot, Basic-RAG and adjusted parameters of LLM-Endpoints to achieve better results.

Added Default prompts for RAG-methods as well as possibilty for user to pass a custom prompt.

Also added examples for the new methods as well as refined existing ones.

Also added an evaluation script to evaluate all RAG-methods on various datasets.